### PR TITLE
Attempt #3 Adding Workflow file to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,160 @@
+# GroceryApp Sprint 3 - Minimal Test Pipeline
+# UC07: Grocery List Sharing & UC08: Product Search Implementation
+
+name: CI - Sprint 3 Testing
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+# Cancel older runs to save resources
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_VERSION: '7.0.x'
+  SOLUTION_FILE: 'Grocery.sln'
+
+jobs:
+  # Unit Tests (A3 Method)
+  unit-tests:
+    name: 'Unit Tests'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          
+      - name: Cache NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+            
+      - name: Restore
+        run: dotnet restore ${{ env.SOLUTION_FILE }}
+        
+      # A3 Method: Unit Tests
+      - name: Test (Unit)
+        run: |
+          dotnet test TestCore/TestCore.csproj \
+            -c Release \
+            --logger "trx;LogFileName=unit-tests.trx" \
+            --collect "XPlat Code Coverage" \
+            --results-directory TestResults/Unit
+            
+      # UC-specific tests
+      - name: Test UC07 & UC08
+        run: |
+          dotnet test ${{ env.SOLUTION_FILE }} \
+            --filter "TestCategory=UC07|TestCategory=UC08" \
+            --logger "trx;LogFileName=uc-tests.trx" \
+            --results-directory TestResults/UC \
+            --no-build
+            
+      - name: Generate Coverage Report
+        run: |
+          dotnet tool update -g dotnet-reportgenerator-globaltool
+          reportgenerator \
+            -reports:**/TestResults/**/coverage.cobertura.xml \
+            -targetdir:CoverageReport \
+            -reporttypes:Html
+            
+      - name: Upload Test Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ github.run_number }}
+          path: |
+            TestResults/**/*.trx
+            TestResults/**/coverage.cobertura.xml
+            CoverageReport/**
+          
+      - name: Publish Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: "TestResults/**/*.trx"
+
+  # Integration Tests  
+  integration-tests:
+    name: 'Integration Tests'
+    runs-on: windows-latest
+    needs: unit-tests
+    if: success()
+    
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          SA_PASSWORD: 'TestPass123!'
+          ACCEPT_EULA: 'Y'
+        ports:
+          - 1433:1433
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          
+      - name: Install MAUI Workload
+        run: dotnet workload install maui
+        
+      - name: Setup Test Database
+        run: |
+          sqlcmd -S localhost -U SA -P 'TestPass123!' -Q "
+          CREATE DATABASE GroceryApp_Test;
+          USE GroceryApp_Test;
+          CREATE TABLE GroceryLists (Id INT IDENTITY PRIMARY KEY, Name NVARCHAR(100), IsShared BIT);
+          CREATE TABLE Products (Id INT IDENTITY PRIMARY KEY, Name NVARCHAR(100), Stock INT, IsAvailable BIT);
+          INSERT INTO Products VALUES ('Bread', 50, 1), ('Milk', 30, 1), ('Apples', 100, 1);"
+        shell: cmd
+        
+      - name: Restore
+        run: dotnet restore ${{ env.SOLUTION_FILE }}
+        
+      - name: Test (Integration)
+        run: |
+          dotnet test ${{ env.SOLUTION_FILE }} \
+            --filter "TestCategory=Integration" \
+            --logger "trx;LogFileName=integration-tests.trx" \
+            --results-directory TestResults/Integration \
+            -c Release
+        env:
+          CONNECTION_STRING: "Server=localhost;Database=GroceryApp_Test;User Id=SA;Password=TestPass123!;TrustServerCertificate=true"
+          
+      - name: Test (UI)
+        run: |
+          dotnet test ${{ env.SOLUTION_FILE }} \
+            --filter "TestCategory=UI" \
+            --logger "trx;LogFileName=ui-tests.trx" \
+            --results-directory TestResults/UI \
+            -c Release
+        continue-on-error: true
+        
+      - name: Upload Integration Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-results-${{ github.run_number }}
+          path: TestResults/**/*.trx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
-      # Restore the solution (safe – restore ≠ build, and ensures references for TestCore)
-      - name: Restore (solution)
-        run: dotnet restore ${{ env.SOLUTION_FILE }}
+      # Restore projects needed for tests (safe – restore ≠ build, ensures refs for TestCore; skips MAUI app)
+      - name: Restore (core + data + tests)
+        run: |
+          dotnet restore Grocery.Core/Grocery.Core.csproj
+          dotnet restore Grocery.Core.Data/Grocery.Core.Data.csproj
+          dotnet restore TestCore/TestCore.csproj
 
       # Run the unit tests for TestCore (build happens implicitly here)
       - name: Test (TRX + Coverage)
@@ -58,7 +61,7 @@ jobs:
 
       - name: Create HTML coverage
         run: |
-          reportgenerator -reports:**/TestResults/**/coverage.cobertura.xml -targetdir:CoverageReport -reporttypes:Html
+          ~/.dotnet/tools/reportgenerator -reports:**/TestResults/**/coverage.cobertura.xml -targetdir:CoverageReport -reporttypes:Html
         shell: bash
 
       # Artefacts required by the rubric (always upload, even on failures)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,3 @@
-# GroceryApp Sprint 3 - Minimal Test Pipeline
-# UC07: Grocery List Sharing & UC08: Product Search Implementation
-
 name: CI - Sprint 3 Testing
 
 on:
@@ -10,35 +7,35 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:
 
-# Cancel older runs to save resources
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
+  checks: write
+  pull-requests: write
 
 env:
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-  DOTNET_VERSION: '7.0.x'
+  DOTNET_VERSION: '8.0.x'
   SOLUTION_FILE: 'Grocery.sln'
 
 jobs:
-  # Unit Tests (A3 Method)
   unit-tests:
-    name: 'Unit Tests'
+    name: Unit Tests (A3)
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-          
+
       - name: Cache NuGet
         uses: actions/cache@v4
         with:
@@ -46,115 +43,39 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
-            
-      - name: Restore
+
+      # Restore the solution (safe – restore ≠ build, and ensures references for TestCore)
+      - name: Restore (solution)
         run: dotnet restore ${{ env.SOLUTION_FILE }}
-        
-      # A3 Method: Unit Tests
-      - name: Test (Unit)
+
+      # Run the unit tests for TestCore (build happens implicitly here)
+      - name: Test (TRX + Coverage)
+        run: dotnet test TestCore/TestCore.csproj -c Release --logger "trx;LogFileName=testresults.trx" --collect "XPlat Code Coverage"
+
+      # Nice-to-have: human-friendly HTML coverage report
+      - name: Install ReportGenerator
+        run: dotnet tool update -g dotnet-reportgenerator-globaltool
+
+      - name: Create HTML coverage
         run: |
-          dotnet test TestCore/TestCore.csproj \
-            -c Release \
-            --logger "trx;LogFileName=unit-tests.trx" \
-            --collect "XPlat Code Coverage" \
-            --results-directory TestResults/Unit
-            
-      # UC-specific tests
-      - name: Test UC07 & UC08
-        run: |
-          dotnet test ${{ env.SOLUTION_FILE }} \
-            --filter "TestCategory=UC07|TestCategory=UC08" \
-            --logger "trx;LogFileName=uc-tests.trx" \
-            --results-directory TestResults/UC \
-            --no-build
-            
-      - name: Generate Coverage Report
-        run: |
-          dotnet tool update -g dotnet-reportgenerator-globaltool
-          reportgenerator \
-            -reports:**/TestResults/**/coverage.cobertura.xml \
-            -targetdir:CoverageReport \
-            -reporttypes:Html
-            
-      - name: Upload Test Artifacts
+          reportgenerator -reports:**/TestResults/**/coverage.cobertura.xml -targetdir:CoverageReport -reporttypes:Html
+        shell: bash
+
+      # Artefacts required by the rubric (always upload, even on failures)
+      - name: Upload test artefacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ github.run_number }}
           path: |
-            TestResults/**/*.trx
-            TestResults/**/coverage.cobertura.xml
+            **/TestResults/*.trx
+            **/TestResults/**/coverage.cobertura.xml
             CoverageReport/**
-          
-      - name: Publish Test Results
+
+      # Visible summary on the run/PR (helps with the testrapportage)
+      - name: Publish test summary
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          files: "TestResults/**/*.trx"
-
-  # Integration Tests  
-  integration-tests:
-    name: 'Integration Tests'
-    runs-on: windows-latest
-    needs: unit-tests
-    if: success()
-    
-    services:
-      sqlserver:
-        image: mcr.microsoft.com/mssql/server:2022-latest
-        env:
-          SA_PASSWORD: 'TestPass123!'
-          ACCEPT_EULA: 'Y'
-        ports:
-          - 1433:1433
-    
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          
-      - name: Install MAUI Workload
-        run: dotnet workload install maui
-        
-      - name: Setup Test Database
-        run: |
-          sqlcmd -S localhost -U SA -P 'TestPass123!' -Q "
-          CREATE DATABASE GroceryApp_Test;
-          USE GroceryApp_Test;
-          CREATE TABLE GroceryLists (Id INT IDENTITY PRIMARY KEY, Name NVARCHAR(100), IsShared BIT);
-          CREATE TABLE Products (Id INT IDENTITY PRIMARY KEY, Name NVARCHAR(100), Stock INT, IsAvailable BIT);
-          INSERT INTO Products VALUES ('Bread', 50, 1), ('Milk', 30, 1), ('Apples', 100, 1);"
-        shell: cmd
-        
-      - name: Restore
-        run: dotnet restore ${{ env.SOLUTION_FILE }}
-        
-      - name: Test (Integration)
-        run: |
-          dotnet test ${{ env.SOLUTION_FILE }} \
-            --filter "TestCategory=Integration" \
-            --logger "trx;LogFileName=integration-tests.trx" \
-            --results-directory TestResults/Integration \
-            -c Release
-        env:
-          CONNECTION_STRING: "Server=localhost;Database=GroceryApp_Test;User Id=SA;Password=TestPass123!;TrustServerCertificate=true"
-          
-      - name: Test (UI)
-        run: |
-          dotnet test ${{ env.SOLUTION_FILE }} \
-            --filter "TestCategory=UI" \
-            --logger "trx;LogFileName=ui-tests.trx" \
-            --results-directory TestResults/UI \
-            -c Release
-        continue-on-error: true
-        
-      - name: Upload Integration Results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-results-${{ github.run_number }}
-          path: TestResults/**/*.trx
+          files: "**/TestResults/*.trx"
+          check_name: "Test Results"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow file for continuous integration (CI) focused on Sprint 3 testing. The workflow automates the process of restoring dependencies, running unit tests, generating coverage reports, and uploading test artefacts for the `Grocery` solution. This will help ensure code quality and provide visibility into test results for every push and pull request targeting the `main` and `develop` branches.

Key additions in the CI workflow:

**CI Workflow Setup:**

* Added a new workflow file `.github/workflows/ci.yml` that triggers on pushes and pull requests to `main` and `develop`, as well as manual dispatches.
* Configured concurrency to prevent overlapping CI runs for the same branch, and set appropriate permissions for contents, checks, and pull requests.

**Testing and Reporting Automation:**

* Automated restoring of project dependencies and running unit tests for the `TestCore` project, including code coverage collection.
* Integrated HTML code coverage report generation using `reportgenerator`, and set up artifact upload for test results and coverage reports.
* Added a step to publish a human-readable summary of test results directly on the GitHub run or pull request.